### PR TITLE
change assignment to textControl using form.patch

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -18,7 +18,7 @@
       <ion-input type="text" [(ngModel)]="dataURL"></ion-input>
       <ion-button (click)="grabData()">Grab Sentence</ion-button>
     </ion-item>
-    <div class="alert warning-alert" *ngIf="apiCallInvalid">Oops! Invalid API Response, it should contain "description"
+    <div class="alert warning-alert" *ngIf="apiCallInvalid && !formHandler.valid">Oops! Invalid API Response, it should contain "description"
       key</div>
     <form [formGroup]="formHandler" (ngSubmit)="doSubmit(formHandler.value)" class="login-form" action="#"
       method="post">

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -34,7 +34,7 @@ export class HomePage {
   grabData() {
     this.apiCallProgress = true;
     this.apiCallInvalid = false;
-    this.formHandler.value.textControl = '';
+    this.formHandler.patchValue({ textControl: ''});
     this.numberOfWords = 0;
     this.api.grabText(this.dataURL).subscribe((result) => {
       if (result.hasOwnProperty('description')) {


### PR DESCRIPTION
This should fix little bug when user grab from non existent or from API call that doesn't have key description. 
Previously we update using 
```sh
this.formHandler.value.textControl = ""
```
which apparently doesn't change displayed value
changing above code to
```sh
this.formHandler.patch({ textControl: ""});
```
fix this behaviour

this issue should be closed after merged